### PR TITLE
Add PhD defense announcement to latest news

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,6 +28,20 @@ import HorizontalCard from "../components/HorizontalCard.astro";
       <div class="card bg-base-100 shadow-sm border-l-4" style="border-left-color: #85B09A;">
         <div class="card-body p-4">
           <div class="flex items-center gap-2 mb-2">
+            <span class="badge badge-sm" style="background-color: #85B09A; color: white;">Milestone</span>
+            <span class="text-sm text-gray-500">26 November 2024</span>
+          </div>
+          <h3 class="font-semibold">Successfully defended my PhD!</h3>
+          <p class="text-sm text-gray-600">
+            Thrilled to share that I successfully defended my PhD on 26 November with my supervisors John Dudley and Ondřej
+            Dušek. Thank you all for the support along the way.
+          </p>
+        </div>
+      </div>
+
+      <div class="card bg-base-100 shadow-sm border-l-4" style="border-left-color: #85B09A;">
+        <div class="card-body p-4">
+          <div class="flex items-center gap-2 mb-2">
             <span class="badge badge-sm" style="background-color: #85B09A; color: white;">Talk</span>
             <span class="text-sm text-gray-500">August 2025</span>
           </div>


### PR DESCRIPTION
## Summary
- add a milestone card announcing my successful PhD defense on 26 November 2024
- highlight supervisors John Dudley and Ondřej Dušek in the news entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e2a1aa0b48323b83ebb02cbb62133)